### PR TITLE
Returning Promises In Tests

### DIFF
--- a/code/04-testing-async-code-with-promises/async/async-example.test.js
+++ b/code/04-testing-async-code-with-promises/async/async-example.test.js
@@ -21,7 +21,7 @@ it('should generate a token value', (done) => {
 it('should generate a token value', () => {
   const testUserEmail = 'test@test.com';
 
-  expect(generateTokenPromise(testUserEmail)).resolves.toBeDefined();
+  return expect(generateTokenPromise(testUserEmail)).resolves.toBeDefined();
 });
 
 it('should generate a token value', async () => {


### PR DESCRIPTION
Even though the test worked as expected in the "Testing Asynchronous Code With Promises & async / await" lecture (@2:55 time), you should actually return the promise assertion in your tests